### PR TITLE
fix: hopefully solves slf4j issue

### DIFF
--- a/core/src/main/java/com/mornati/sample/service/PluginService.java
+++ b/core/src/main/java/com/mornati/sample/service/PluginService.java
@@ -8,9 +8,14 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.StringJoiner;
+
 import javax.annotation.PreDestroy;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -44,6 +49,10 @@ public class PluginService {
     try {
       // Create an instance and initialise the framework.
       FrameworkFactory factory = new org.apache.felix.framework.FrameworkFactory();
+      
+      Map<String, String> felixProperties = new HashMap<>(felixConfiguration.getPluginsService());
+      felixProperties.put("org.osgi.framework.system.packages.extra", findPackageNamesStartingWith());
+      
       framework = factory.newFramework(felixConfiguration.getPluginsService());
       framework.init();
 
@@ -67,6 +76,23 @@ public class PluginService {
     }
   }
 
+  /**
+   * Felix provides an isolated classloader to each bundle. Bundles need to declare what packages they need in there manifest.
+   * If a Bundle needs e.g. something from orgl.slf4j it aither needs to have it as classes itself or another bundle must export this packages.
+   * java.* packages will be provided by the framework from the classloader it was created with. We can modify this, by giving the framework
+   * a list of additional packages, that are provided by the spring boot container (should include e.g.slf4j)
+  * @return
+  */
+  public String findPackageNamesStartingWith() {
+	  StringJoiner joiner = new StringJoiner(",");  
+	  Arrays.asList(Package.getPackages()).stream()
+	        .map(Package::getName)
+	        .filter(n -> !n.startsWith("java")) // the framework will expose this automatically
+	        .filter(n -> !n.startsWith("org.apache.felix")) // we don't want the inner workings of the felix framework exposed
+	        .forEach(joiner::add);
+	  return joiner.toString();
+	}
+  
   @PreDestroy
   public void destroy() throws BundleException, InterruptedException {
     log.info("Stopping plugins OSGi service...");

--- a/sample-bundle-scr/pom.xml
+++ b/sample-bundle-scr/pom.xml
@@ -52,14 +52,16 @@
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <bnd><![CDATA[
-          -includeresource: slf4j-api-[0-9.]*.jar;logback-*-[0-9.]*.jar;lib:=true
-          Import-Package: org.osgi.framework,com.mornati.sample.commons.plugins,com.mornati.sample.commons.plugins.dto
-          Private-Package: com.mornati.sample.plugin.psp.scr
-          Export-Service: com.mornati.sample.plugin.psp.scr.SampleScr
-          ]]></bnd>
-        </configuration>
+<!--         All this will be calculated by the bnd-maven-plugin -->
+<!--         SLF4j and the rest should now be provided by the framework -->
+<!--         <configuration> -->
+<!--           <bnd><![CDATA[ -->
+<!--           -includeresource: slf4j-api-[0-9.]*.jar;logback-*-[0-9.]*.jar;lib:=true -->
+<!--           Import-Package: org.osgi.framework,com.mornati.sample.commons.plugins,com.mornati.sample.commons.plugins.dto -->
+<!--           Private-Package: com.mornati.sample.plugin.psp.scr -->
+<!--           Export-Service: com.mornati.sample.plugin.psp.scr.SampleScr -->
+<!--           ]]></bnd> -->
+<!--         </configuration> -->
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/sample-bundle/pom.xml
+++ b/sample-bundle/pom.xml
@@ -36,6 +36,7 @@
           <target>${java.version}</target>
         </configuration>
       </plugin>
+<!--       You might want to condider replacing this with the config from the sample-bundle-src config -->
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>


### PR DESCRIPTION
This I couldn't really test, but it demonstrates how you can provide classes and dependencies spring boot brings along to any bundle installed in the felix framework.

If you want to see how classloading in osgi works, you find a nice diagram here: https://docs.osgi.org/specification/osgi.core/7.0.0/framework.module.html#framework.module.overallsearchorder

Signed-off-by: Jürgen Albert <j.albert@data-in-motion.biz>