### PR TITLE
fix: maven warnings

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.mornati.sample</groupId>
       <artifactId>commons</artifactId>
-      <version>${parent.version}</version>
+      <version>${project.parent.version}</version>
     </dependency>
   </dependencies>
 

--- a/sample-bundle-scr/pom.xml
+++ b/sample-bundle-scr/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.mornati.sample</groupId>
       <artifactId>commons</artifactId>
-      <version>${parent.version}</version>
+      <version>${project.parent.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/sample-bundle/pom.xml
+++ b/sample-bundle/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>com.mornati.sample</groupId>
       <artifactId>commons</artifactId>
-      <version>${parent.version}</version>
+      <version>${project.parent.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Remove following maven warnings:

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.mornati.sample:core:jar:0.0.1-SNAPSHOT
[WARNING] The expression ${parent.version} is deprecated. Please use ${project.parent.version} instead.
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.mornati.sample:sample-bundle:bundle:0.0.1-SNAPSHOT
[WARNING] The expression ${parent.version} is deprecated. Please use ${project.parent.version} instead.
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.mornati.sample:sample-bundle-scr:jar:0.0.1-SNAPSHOT
[WARNING] The expression ${parent.version} is deprecated. Please use ${project.parent.version} instead.
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```