### PR TITLE
fix: add 'javax.naming' to the Import-Package directive

### DIFF
--- a/sample-bundle-scr/pom.xml
+++ b/sample-bundle-scr/pom.xml
@@ -55,7 +55,7 @@
         <configuration>
           <bnd><![CDATA[
           -includeresource: slf4j-api-[0-9.]*.jar;logback-*-[0-9.]*.jar;lib:=true
-          Import-Package: org.osgi.framework,org.xml.sax,org.xml.sax.helpers,javax.xml.parsers,com.mornati.sample.commons.plugins,com.mornati.sample.commons.plugins.dto
+          Import-Package: org.osgi.framework,org.xml.sax,org.xml.sax.helpers,javax.xml.parsers,javax.naming,com.mornati.sample.commons.plugins,com.mornati.sample.commons.plugins.dto
           Private-Package: com.mornati.sample.plugin.psp.scr
           Export-Service: com.mornati.sample.plugin.psp.scr.SampleScr
           ]]></bnd>


### PR DESCRIPTION
fixes #10

See this [stackoverflow question](https://stackoverflow.com/questions/15239943/getting-java-lang-noclassdeffounderror-javax-naming-namingexception-error-when) 

`javax.naming` needs to be added to the `Import-Package`